### PR TITLE
Limit RadioMenuMaxPageItems for doi as well

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -372,6 +372,7 @@
 			"engine"	"blade"
 			"engine"	"insurgency"
 			"engine"	"mcv"
+			"engine"	"doi"
 		}
 		
 		"Keys"


### PR DESCRIPTION
The various radio menus are broken in Day of Infamy on current sourcemod versions due to the same engine issue being present as is in csgo/insurgency.